### PR TITLE
fix: name category portuguese

### DIFF
--- a/finances_frontend/src/app/(logged)/categories/page.tsx
+++ b/finances_frontend/src/app/(logged)/categories/page.tsx
@@ -8,7 +8,7 @@ export default async function CategoriesPage() {
     <main className="flex flex-col items-start w-full py-4 px-32 mt-10 gap-14">
       <Tabs defaultValue="expenses" className="w-full">
         <div className="flex justify-between w-full items-center">
-          <Title name="Catégorias" />
+          <Title name="Categorias" />
           <TabsContent value="expenses" className="flex-0">
             <NewCategoryButton typeCategory="expenses" />
           </TabsContent>

--- a/finances_frontend/src/app/(logged)/transactions/components/TableTransaction/Modals/ModalFormFilter.tsx
+++ b/finances_frontend/src/app/(logged)/transactions/components/TableTransaction/Modals/ModalFormFilter.tsx
@@ -36,7 +36,7 @@ export const ModalFormFilter = () => {
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <label>Catégorias</label>
+            <label>Categorias</label>
             <select className="rounded-2xl border p-2 shadow-sm">
               <option value="all">Todas</option>
               <option value="food">Alimentação</option>

--- a/finances_frontend/src/components/Default/Modals/ModalCategoryIndividual.tsx
+++ b/finances_frontend/src/components/Default/Modals/ModalCategoryIndividual.tsx
@@ -12,19 +12,19 @@ export const ModalCategoryIndividual = ({ isEdit }: { isEdit?: boolean }) => {
   return (
     <DialogContent className="rounded-2xl">
       <DialogTitle className="text-2xl font-bold">
-        {!isEdit ? "Criar nova" : "Editar"} catégoria
+        {!isEdit ? "Criar nova" : "Editar"} categoria
       </DialogTitle>
       <form action="">
         <div className="grid gap-6 py-4">
           <div className="flex flex-col gap-2 items-start">
-            <label className="text-right">Nome da Catégoria</label>
+            <label className="text-right">Nome da Categoria</label>
             <div className="flex gap-2 w-full items-center">
               <input className="w-full border-b" />
             </div>
           </div>
           <div className="flex gap-4 items-center justify-between">
             <div className="flex flex-col gap-2 items-start">
-              <label className="text-right">Cor da Catégoria</label>
+              <label className="text-right">Cor da Categoria</label>
               <ColorPicker
                 selectedColor={categoryColor}
                 onChange={setCategoryColor}

--- a/finances_frontend/src/components/Default/Modals/ModalIndividualTransaction.tsx
+++ b/finances_frontend/src/components/Default/Modals/ModalIndividualTransaction.tsx
@@ -91,7 +91,7 @@ export const ModalIndividualTransaction = (
           <div className="flex justify-between gap-4 items-center">
             {individualTransactionProps.typeTransaction !== "transfer" && (
               <div className="flex flex-col gap-2 items-start w-full">
-                <label className="text-right">Catégoria</label>
+                <label className="text-right">Categoria</label>
                 <div className="flex gap-2 w-full items-center">
                   <CiPalette size={24} />
                   <select className="w-full border-b">


### PR DESCRIPTION
This pull request focuses on correcting the spelling of the word "Categoria" across multiple components in the `finances_frontend` project. The changes ensure consistency in the terminology used throughout the application.

### Text corrections for "Categoria":

* [`finances_frontend/src/app/(logged)/categories/page.tsx`](diffhunk://#diff-964cd6bd3b3d5dca2686b6845339086497b39ef7a4e9d006686014fa690377f3L11-R11): Fixed the title text from "Catégorias" to "Categorias" in the `CategoriesPage` component.
* [`finances_frontend/src/app/(logged)/transactions/components/TableTransaction/Modals/ModalFormFilter.tsx`](diffhunk://#diff-d8951f9805c5eb267043b1f0c11868f0aa2e62e38f39bbd14e190baa81cc54e0L39-R39): Updated the label text from "Catégorias" to "Categorias" in the `ModalFormFilter` component.
* [`finances_frontend/src/components/Default/Modals/ModalCategoryIndividual.tsx`](diffhunk://#diff-0abfc4edf3c79f9db129b7d0c52fe840b1006efe3bec365ff9a0f191debc16e8L15-R27): Corrected multiple instances of "Catégoria" to "Categoria" in the `ModalCategoryIndividual` component, including in dialog titles and labels.
* [`finances_frontend/src/components/Default/Modals/ModalIndividualTransaction.tsx`](diffhunk://#diff-c7317cbab7f9cef38e3189681abe270bb07a55060adcd2d05c7ab8721ab9408eL94-R94): Updated the label text from "Catégoria" to "Categoria" in the `ModalIndividualTransaction` component.